### PR TITLE
Hand position and size-scale preprocessing for easier training and better performance at large distances

### DIFF
--- a/hand_pose_transform.py
+++ b/hand_pose_transform.py
@@ -1,0 +1,41 @@
+import numpy as np
+from sklearn.base import BaseEstimator, TransformerMixin
+
+
+class HandPoseTransform(BaseEstimator, TransformerMixin):
+    """
+            Custom SKLearn Pipeline Transform function for hand pose data.
+
+            Use the wrist landmark as the origin of the coordinate system.  Shift all hand positions
+            to be relative to the wrist.  Scale the max landmark position to have a 3D length = 1
+            from the wrist-origin.
+
+            Assumes input data is tabular with each landmark's x, y, & z coords flattened into
+            three separate columns.  Also assumes wrist position's z coord is already nearly 0.
+
+    """
+    def __init__(self):
+        pass
+
+    def fit(self, X, y=0):
+        return self
+
+    def transform(self, X, y=None):
+        X_ = X.copy()
+
+        def _shift_and_scale(row):
+            # Subtract off wrist position
+            row[0::3] = row[0::3] - row[0]
+            row[1::3] = row[1::3] - row[1]
+            # z origin is already anchored to the wrist, so no need to shift
+
+            # Scale so that the max extension of any hand landmark from the wrist is 1.
+            norm = np.max(
+                np.sqrt(np.square(row[0::3]) + np.square(row[1::3]) + np.square(row[2::3]))
+            )
+            row[0::3] = row[0::3] / norm
+            row[1::3] = row[1::3] / norm
+            row[2::3] = row[2::3] / norm
+            return row
+
+        return np.apply_along_axis(_shift_and_scale, 1, X_)

--- a/hand_pose_transform.py
+++ b/hand_pose_transform.py
@@ -33,9 +33,7 @@ class HandPoseTransform(BaseEstimator, TransformerMixin):
             norm = np.max(
                 np.sqrt(np.square(row[0::3]) + np.square(row[1::3]) + np.square(row[2::3]))
             )
-            row[0::3] = row[0::3] / norm
-            row[1::3] = row[1::3] / norm
-            row[2::3] = row[2::3] / norm
+            row = row / norm
             return row
 
         return np.apply_along_axis(_shift_and_scale, 1, X_)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyAutoGUI==0.9.52
 mediapipe==0.8.3
 numpy==1.19.3
 opencv-python==4.5.1.48
+pandas==1.1.5

--- a/train_hand_poses_classifier.py
+++ b/train_hand_poses_classifier.py
@@ -4,8 +4,10 @@ from sklearn.model_selection import train_test_split
 from sklearn.metrics import classification_report
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import RandomizedSearchCV
+from sklearn.pipeline import Pipeline
 import pickle
 import argparse
+from hand_pose_transform import HandPoseTransform
 
 parser = argparse.ArgumentParser(description="List Parameters.")
 parser.add_argument("-d", "--dataset_path", type=str, default='dataset_train.csv',
@@ -35,17 +37,26 @@ print([(key, len_per_class[key]) for key in len_per_class.keys()], end='\n\n')
 
 # train test split
 Y = df['class'].values
-del df['class']
-del df['hand']
-X = df.values
+xcols = list(df.columns)
+xcols.remove('hand')
+xcols.remove('class')
+X = df[xcols].values
 X_train, X_test, Y_train, Y_test = train_test_split(
     X, Y, test_size=test_size, random_state=42, stratify=Y)
 print(f'Train Size {len(X_train)}')
 print(f'Test Size {len(X_test)}')
 
-# Train SVC
+# Train SVC inside of a Pipeline
+scale_hands = True
+if scale_hands:
+    svc_model = Pipeline([
+        ('scaler', HandPoseTransform()),
+        ('svc', SVC(C=1, kernel='linear', random_state=42))
+    ])
+else:
+    svc_model = SVC(C=1, kernel='linear', random_state=42)
+
 print(f'Training SVC with {len(X_train)} tuples...')
-svc_model = SVC(C=1, kernel='linear', random_state=42)
 svc_model.fit(X_train, Y_train)
 print('Train Completed', end='\n\n')
 
@@ -54,13 +65,17 @@ print(f'Testing SVC with {len(X_test)} tuples...', end='\n\n')
 predict_svc_model = svc_model.predict(X_test)
 print(classification_report(Y_test, predict_svc_model), end='\n\n')
 print(accuracy_score(Y_test, predict_svc_model), end='\n\n')
-del svc_model, predict_svc_model
 
 # Grid Search SVC - Train/Validation
 print('Grid Search Training Starting...')
-svc_model = SVC(random_state=42)
-grid_svc = {'C': [0.1, 1, 10, 100], 'gamma': [1, 0.1, 0.01,
-                                              0.001], 'kernel': ['linear', 'rbf', 'poly', 'sigmoid']}
+# svc_model = SVC(random_state=42)
+grid_svc = {'C': [0.1, 1, 10, 100],
+            'gamma': [1, 0.1, 0.01, 0.001],
+            'kernel': ['linear', 'rbf', 'poly', 'sigmoid']}
+if scale_hands:  # For a Pipeline with multiple steps, we need to specify where param belongs
+    for key in grid_svc.keys():
+        grid_svc['svc__' + key] = grid_svc.pop(key)
+
 svc_model_optimized = RandomizedSearchCV(estimator=svc_model, param_distributions=grid_svc,
                                          n_iter=10, cv=3, random_state=42)
 svc_model_optimized.fit(X_train, Y_train)
@@ -80,9 +95,12 @@ print(best_parameters_svc, end='\n\n')
 
 # Generate SVC Model - Best Parameters founded in Grid Search
 print('Training Final SVC Model with Best Parameters')
-svc_model = SVC(probability=True).set_params(**best_parameters_svc)
+
+# Add in that we want to predict probability instead of class (for multi-class estimates)
+best_parameters_svc['svc__probability' if scale_hands else 'probability'] = True
+svc_model.set_params(**best_parameters_svc)
 svc_model.fit(X, Y)
-print('Final traning completed with sucessful', end='\n\n')
+print('Final training completed successfully', end='\n\n')
 
 # Saving SVC Best Model
 print('Saving Final SVC Model...')


### PR DESCRIPTION
Add image preprocessing alongside the SVC model to make all hand landmarks relative to the wrist.  That is,  the wrist landmark is used as the origin (0, 0, 0) meaning the position of the hand within the frame becomes irrelevant.  This should make training a lot easier and more focused as you don't need to move your hand around within the frame to generate proper training coverage.  

Also important is that the max hand landmark 3D distance from 0 is used to normalize the size of the hand.  This scaling means that as the hand moves closer or farther away from the camera, the SVC sees them all as the same size, so it doesn't need to waste capacity learning different hand sizes.  The training also doesn't need to spend a lot of time covering different distances.  And finally people with small or large hands should have an equally good experience.  

(Cheers on a very nice project - hope this little contribution helps!)